### PR TITLE
Patch database seeding with IssueColumn

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,6 +18,7 @@ html lang="zh-TW"
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true
     = javascript_include_tag 'application', 'data-turbolinks-track' => true
     = csrf_meta_tags
+    = display_meta_tags
 
   - if params[:controller] == 'static_pages'
     body class='jrf-index-body' style='background-image: url(/images/backgrounds/102.jpg);'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,6 +58,11 @@ record_path = Rails.root.join('db', 'data', 'records.json')
 if File.file?(record_path)
   File.readlines(record_path).each do |line|
     record_data = JSON.parse(line)
+    unless record_data and record_data.length == 36
+      puts "[格式不正確] #{line}"
+      next
+    end
+
     record = Record.new
     # 資料識別碼
     record.identifier = record_data[3].strip
@@ -218,7 +223,6 @@ if File.file?(magazine_path)
       magazine.created_at = published_at
       magazine.save
     end
-    article.magazine = magazine
     if article_data["專欄"].blank?
       article_data["專欄"] = "其他"
     end
@@ -235,7 +239,8 @@ if File.file?(magazine_path)
       issue_column.magazine = magazine
       issue_column.column = column
       issue_column.page = article_page
-    elsif issue_column.page > article_page
+    end
+    if issue_column.page > article_page
       issue_column.page = article_page
       issue_column.save
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -214,7 +214,7 @@ if File.file?(magazine_path)
       magazine.id = article_data["期"]
       published_at = Date.strptime(article_data["日期"], "%Y-%m-%d") rescue Date.strptime(article_data["日期"], "%m/%d/%Y")
       magazine.published_at = published_at
-      magazine.name = "司改雜誌第#{article_data["期"]}期"
+      magazine.name = "司改雜誌第 #{article_data["期"]} 期"
       magazine.created_at = published_at
       magazine.save
     end
@@ -228,11 +228,22 @@ if File.file?(magazine_path)
       column.name = article_data["專欄"]
       column.save
     end
+    article_page = article_data["頁碼"]
+    issue_column = IssueColumn.where(magazine: magazine, column: column).first
+    unless issue_column
+      issue_column = IssueColumn.new
+      issue_column.magazine = magazine
+      issue_column.column = column
+      issue_column.page = article_page
+    elsif issue_column.page > article_page
+      issue_column.page = article_page
+      issue_column.save
+    end
+    article.issue_column = issue_column
     if article_data["專欄"] == "封面故事"
       article.is_cover = true
     end
-    article.column = column
-    article.page = article_data["頁碼"]
+    article.page = article_page
     article.title = article_data["標題"].gsub(/\n/, '')
     article.author = article_data["作者"]
     article.content = simple_format(article_data["全文"]).gsub(/\n/, '')


### PR DESCRIPTION
This new seeding script would automatically create `IssueColumn` if not yet created. Integer is assumed on writing conditions.

Also, old `magazine.json.bak` is removed, due to the fact that we have Git as our backup. :)

Finally, the provided `records.json` has several malformed lines (missing fields or field mismatch), which should not occur while exporting from Excel. We should find out if JSON converting preprocess cause any problems.